### PR TITLE
Update Rope to Version 0.21.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rope" %}
-{% set version = "0.19.0" %}
+{% set version = "0.21.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 64e6d747532e1f5c8009ec5aae3e5523a5bcedf516f39a750d57d8ed749d90da
+  sha256: 366789e069a267296889b2ee7631f9278173b5e7d468f2ea08abe26069a52aef
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,7 @@ test:
 about:
   home: https://github.com/python-rope/rope
   license_file: COPYING
-  license: LGPL 3.0-or-later
+  license: LGPL-3.0-or-later
   license_family: LGPL
   summary: A python refactoring library
   dev_url: https://github.com/python-rope/rope

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,7 @@ test:
 about:
   home: https://github.com/python-rope/rope
   license_file: COPYING
-  license: LGPL 3.0
+  license: LGPL 3.0-or-later
   license_family: LGPL
   summary: A python refactoring library
   dev_url: https://github.com/python-rope/rope

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   number: 0
+  skip: True # [py<36]
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 
@@ -22,7 +23,7 @@ requirements:
     - setuptools
 
   run:
-    - python
+    - python >=3.6
 
 test:
   imports:
@@ -38,6 +39,7 @@ test:
     - rope.refactor.importutils
   requires:
     - pip
+    - python <3.10
   commands:
     - pip check
 


### PR DESCRIPTION
1. check the upstream
https://github.com/python-rope/rope/tree/0.21.0

2. check the pinnings
https://github.com/python-rope/rope/blob/0.21.0/setup.py
https://github.com/python-rope/rope/blob/0.21.0/pytest.ini
https://github.com/python-rope/rope/blob/0.21.0/pyproject.toml

3. check changelogs
https://github.com/python-rope/rope/blob/0.21.0/CHANGELOG.md

4. additional research
https://github.com/conda-forge/rope-feedstock/issues

5. verify dev_url
https://github.com/python-rope/rope

6. verify doc_url
https://pypi.python.org/pypi/rope

7. added pip to the test section

8. verify the test section
9. additional tests

In order to test the `rope` package version `0.21.0` the following command was used:
`conda build rope-feedstock --test` 
The test result was the following:
`All tests passed`
