### PR TITLE
rope 0.22.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,7 @@ test:
     - rope.refactor.importutils
   requires:
     - pip
+    - python <3.10
   commands:
     - pip check
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,6 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<36]
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 
@@ -22,7 +21,7 @@ requirements:
     - wheel
     - setuptools
   run:
-    - python >=3.6
+    - python
 
 test:
   imports:
@@ -38,7 +37,6 @@ test:
     - rope.refactor.importutils
   requires:
     - pip
-    - python <3.10
   commands:
     - pip check
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rope" %}
-{% set version = "0.21.1" %}
+{% set version = "0.22.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 4fe61ea25ca64f1819be57fbb44ee07ca98b3dce08a0ceaaf3c6d6166b603f7f
+  sha256: b00fbc064a26fc62d7220578a27fd639b2fad57213663cc396c137e92d73f10f
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,6 @@ source:
 build:
   number: 0
   skip: True  # [py<36]
-
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 


### PR DESCRIPTION
Update rope to 0.22.0

Version change: bump version number from 0.21.1 to 0.22.0
Bug Tracker: new open issues https://github.com/python-rope/rope/issues
Upstream license:  License file:  https://github.com/python-rope/rope/blob/master/COPYING
Upstream Changelog: https://github.com/python-rope/rope/blob/master/CHANGELOG.md
Upstream setup.py:  https://github.com/python-rope/rope/blob/0.22.0/setup.py
Upstream pyproject.toml:  https://github.com/python-rope/rope/blob/0.22.0/pyproject.toml

The package rope is mentioned inside the packages:
python-language-server | python-lsp-server

Actions:
1. Do not skip `py<36`, see https://github.com/python-rope/rope/blob/b164d8e7baf5a713b524c784ab9e54462236e817/setup.py#L21

Result:
- all-succeeded


