### PR TITLE
rope 1.4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rope" %}
-{% set version = "0.22.0" %}
+{% set version = "1.4.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: b00fbc064a26fc62d7220578a27fd639b2fad57213663cc396c137e92d73f10f
+  sha256: 7d5a34235ff4a242b71f249b5617a9c54112e145ba4701a41e2f4f96942e5899
 
 build:
   number: 0


### PR DESCRIPTION
**Recipe directory diff between current master and this update:**
``` diff
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index 4415d8d..cb2c9c8 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rope" %}
-{% set version = "0.22.0" %}
+{% set version = "1.4.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: b00fbc064a26fc62d7220578a27fd639b2fad57213663cc396c137e92d73f10f
+  sha256: 7d5a34235ff4a242b71f249b5617a9c54112e145ba4701a41e2f4f96942e5899
 
 build:
   number: 0

```

**Jira ticket:** []() (-)

**The upstream data:**
Github releases:  https://github.com/python-rope/rope/releases
[Diff between the latest and previous upstream releases](https://github.com/python-rope/rope/compare/0.22.0...1.4.0)
License: https://github.com/python-rope/rope/blob/master/COPYING
Changelog: https://github.com/python-rope/rope/blob/master/CHANGELOG.md
Requirements:
 * setup.py:  https://github.com/python-rope/rope/blob/1.4.0/setup.py
 * pyproject.toml:  https://github.com/python-rope/rope/blob/1.4.0/pyproject.toml

**_Actions:_**

1. 

**_Notes:_**
 * 

**Package's statistics**
<details>

 * Priority C | effort: easy | Category: anaconda | subcategory: dependency | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 1.4.0
 * Release on PyPi:
    * version: 1.5.0
    * date: 2022-11-22T15:07:05
* [PyPi history](https://pypi.org/project/rope/#history)
 * Popularity: 
    * 3 months downloads: 313915.0
Key is not found. 0

</details>

**Other checks:**

<details>

1. - [x] https://github.com/python-rope/rope/tree/1.4.0 exists
2. - [x] https://github.com/python-rope/rope is present
3. - [ ] Check the pinnings
4. - [x] https://github.com/python-rope/rope/blob/master/CHANGELOG.md exists
5. - [ ] Additional research
    https://github.com/python-rope/rope/issues
    200
6. - [x] `dev_url` is present
    https://github.com/python-rope/rope
7. - [ ] `doc_url` error:
    https://pypi.python.org/pypi/rope
    301
7. - [x] `doc_source_url` is present
    https://github.com/python-rope/rope/tree/master/docs
8. - [ ] Verify that the `build_number` is correct
9. - [x] has `setuptools`
10. - [x] has `wheel`
11. - [x] `pip` in test
12. - [ ] Verify the test section
13. - [ ] Verify if the package is `architecture specific`
14. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
15.  - [x] license_file: COPYING is present
16. - [x] License: LGPL-3.0-or-later
    - [ ] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier        |
|:------------------|
| LGPL-3.0-or-later |

17. - [x] license_family LGPL is present
</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/rope-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/rope-feedstock/tree/1.4.0)
* [conda-forge recipe](https://github.com/{upstream}/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/rope)
* [Diff between upstream and feature branch](https://github.com/conda-forge/rope-feedstock/compare/main...AnacondaRecipes:1.4.0)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/rope-feedstock/compare/master...AnacondaRecipes:1.4.0)
* [The last merged PRs](https://github.com/AnacondaRecipes/rope-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 1.4.0 git@github.com:AnacondaRecipes/rope-feedstock.git
```
